### PR TITLE
Update shared_pref.dart

### DIFF
--- a/lib/utils/shared_pref.dart
+++ b/lib/utils/shared_pref.dart
@@ -87,7 +87,7 @@ class AppSharedPref {
         deepThinkingModel: 'deepseek-reasoner',
       );
     }
-    return CustomModel.fromJson(jsonDecode(customModelString));
+    return CustomModel.fromJson(customModelString);
   }
 
   static Future<bool> setCustomModel(CustomModel model) async {


### PR DESCRIPTION
修复一个可能的小bug。
实测在原语句的情况下运行，填写一次url和key之后再次填写并运行会出现报错：
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: type '_Map<String, dynamic>' is not a subtype of type 'String'
#0      AppSharedPref.getCustomModel 
shared_pref.dart:90
#1      OpenaiRequest.init 
openai_request.dart:118
#2      main
main.dart:22
<asynchronous suspension>
Application finished.
Exited (-1).
```
排查后发现`CustomModel.fromJson`接收的是一个string类型的参数，并且内部进行了处理`final json = jsonDecode(jsonString);`
故此修改处可能并不需要` jsonDecode`。将其去掉后程序正常运行。
